### PR TITLE
changing yaml.load to safe_load per security warning

### DIFF
--- a/ini2yaml
+++ b/ini2yaml
@@ -27,15 +27,15 @@ noQuotesNeededRegex = re.compile("^([-.0-9a-zA-Z]+|'[^']+'|\"[^\"]+\")$")
 # Parse host variable and return corresponding YAML object
 def parse_value(value):
   if noQuotesNeededRegex.match(value):  # Integers, booleans and quoted strings strings must not be quoted
-    result = yaml.load('value: ' + value)['value']
+    result = yaml.safe_load('value: ' + value)['value']
   else:
-    result = yaml.load('value: "' + value + '"')['value']
+    result = yaml.safe_load('value: "' + value + '"')['value']
   if isinstance(result, basestring):
     if '\\n' in result:  # Use YAML block literal for multi-line strings
       return literal_unicode(result.replace('\\n', '\n'))
     else:
       try:  # Unwrap nested YAML structures
-        new_result = yaml.load('value: ' + result)['value']
+        new_result = yaml.safe_load('value: ' + result)['value']
         if isinstance(new_result, list) or isinstance(new_result, dict):
           result = new_result
       except:


### PR DESCRIPTION
PyYaml has depricated `yaml.load`.  This upgrades it to safe_load per https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

